### PR TITLE
Utilities: Remove "for android" in App manager's description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ A curated list of awesome F-Droid applications
 
 ## Utilities
 
-- [App manager](https://f-droid.org/packages/io.github.muntashirakon.AppManager/) - A full-featured open source package manager for android.
+- [App manager](https://f-droid.org/packages/io.github.muntashirakon.AppManager/) - A full-featured open source package manager
 
 ## Other


### PR DESCRIPTION
Like I removed it in #4, I think it should be removed here too